### PR TITLE
Added date, to and subject methods to mail

### DIFF
--- a/lib/mbox/mail.rb
+++ b/lib/mbox/mail.rb
@@ -35,6 +35,7 @@ class Mail
 
 		# metadata parsing
 		metadata.parse_from line
+
 		until input.eof? || (line = input.readline).match(options[:separator])
 			break unless line.match(/^>+/)
 
@@ -47,6 +48,13 @@ class Mail
 			break if line.strip.empty?
 
 			current << line
+			if line[0..12] == "Delivered-To:"
+				metadata.parse_to line
+				next
+			end
+			if line[0..7] == "Subject:"
+				metadata.parse_subject line
+			end
 		end until input.eof? || (line = input.readline).match(options[:separator])
 		headers.parse(current)
 
@@ -81,7 +89,19 @@ class Mail
 	def from
 		metadata.from.first.name
 	end
-
+	
+	def date
+		metadata.from.first.date
+	end
+	
+	def to
+		metadata.to.first
+	end
+	
+	def subject
+		metadata.subject.first
+	end
+	
 	def save_to (path)
 		File.open(path, 'w') {|f|
 			f.write to_s

--- a/lib/mbox/mail/metadata.rb
+++ b/lib/mbox/mail/metadata.rb
@@ -20,15 +20,27 @@
 class Mbox; class Mail
 
 class Metadata
-	attr_reader :from
+	attr_reader :from, :to, :subject
 
 	def initialize
 		@from = []
+		@to = []
+		@subject = []
 	end
 
 	def parse_from (line)
 		line.match /^>*From ([^\s]+) (.{24})/ do |m|
 			@from << Struct.new(:name, :date).new(m[1], m[2])
+		end
+	end
+	def parse_to (line)
+		line.match /Delivered-To: (.*)/ do |m|
+			@to << m[1]
+		end
+	end
+	def parse_subject (line)
+		line.match /Subject: (.*)/ do |m|
+			@subject << m[1]
 		end
 	end
 end


### PR DESCRIPTION
I needed to be able to access "subject"  and "date" of the mail easily so I added those modifications which allows one to do mail.date, mail.to and mail.subject as they could do mail.from only before.
