### PR TITLE
escape boundary inside regex

### DIFF
--- a/lib/mbox/mail/content.rb
+++ b/lib/mbox/mail/content.rb
@@ -36,7 +36,7 @@ class Content < Array
 		type    = headers[:content_type]
 
 		if type && type.mime && type.boundary && matches = type.mime.match(%r{multipart/(\w+)})
-			text.sub(/^.*?--#{type.boundary}\n/m, '').sub(/--#{type.boundary}--$/m, '').split("--#{type.boundary}\n").each {|part|
+			text.sub(/^.*?--#{Regexp.escape(type.boundary)}\n/m, '').sub(/--#{Regexp.escape(type.boundary)}--$/m, '').split("--#{type.boundary}\n").each {|part|
 				stream = StringIO.new(part)
 
 				headers = ''


### PR DESCRIPTION
The boundary can have characters that are valid for regular expressions (e.g.
+), which cause the substitution to fail, so must be escaped.
