### PR TITLE
Custardcat add error handling

### DIFF
--- a/lib/mbox/mbox.rb
+++ b/lib/mbox/mbox.rb
@@ -84,16 +84,17 @@ class Mbox
 		end
 	end
 
-    def first(opts = {})
+    def reset()
 		@input.seek 0
-        next(opts)
     end
 
-    def next(opts = {})
+    def has_next()
+    end
+
+    def get_next(opts = {})
 		lock {
             mail = Mail.parse(@input, options.merge(opts))
         }
-        mail
     end
 
 	def each (opts = {})

--- a/lib/mbox/mbox.rb
+++ b/lib/mbox/mbox.rb
@@ -84,6 +84,18 @@ class Mbox
 		end
 	end
 
+    def first(opts = {})
+		@input.seek 0
+        next(opts)
+    end
+
+    def next(opts = {})
+		lock {
+            mail = Mail.parse(@input, options.merge(opts))
+        }
+        mail
+    end
+
 	def each (opts = {})
 		@input.seek 0
 


### PR DESCRIPTION
Added some error handling around mbox parsing. I have several large mbox files that contain mails with invalid headers that caused the parse to abort. What I wanted was for the parse to continue but report any errors found.
I wondered if you might find this useful?
(also, you're using tabs and I inadvertently used spaces ts=4)