### PR TITLE
Add 'id' metadata and 'raw' mail method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.swp
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source "https://rubygems.org"
- 
+
+gem 'call-me'
 gem 'rspec'
  
 group :development do
   gem 'pry'
+  gem 'rake'
 end

--- a/lib/mbox/mail/metadata.rb
+++ b/lib/mbox/mail/metadata.rb
@@ -20,12 +20,14 @@
 class Mbox; class Mail
 
 class Metadata
-	attr_reader :from, :to, :subject
+	attr_reader :from, :to, :subject, :id
 
 	def initialize
 		@from = []
 		@to = []
 		@subject = []
+    @id = []
+    @raw = []
 	end
 
 	def parse_from (line)
@@ -41,6 +43,11 @@ class Metadata
 	def parse_subject (line)
 		line.match /Subject: (.*)/ do |m|
 			@subject << m[1]
+		end
+	end
+	def parse_id (line)
+		line.match /Message-ID: (.*)/ do |m|
+			@id << m[1]
 		end
 	end
 end


### PR DESCRIPTION
With the availability of mail.metadata.id (based on `Message-ID`) and mail.raw, this gem can be used as the basis for a script that can merge multiple mbox files while avoiding message duplication. I don't love the way I've captured the raw mail item so I'm open to feedback.
